### PR TITLE
Prevent comments collection auto-creation

### DIFF
--- a/models/review.js
+++ b/models/review.js
@@ -1,5 +1,5 @@
 import mongoose from 'mongoose'
-import Comment, { commentSchema } from './comment.js'
+import { commentSchema } from './comment.js'
 
 const reviewSchema = new mongoose.Schema({
 	user: {
@@ -29,20 +29,5 @@ const reviewSchema = new mongoose.Schema({
 		ref: 'User',
 	},
 })
-
-/**
- * On deleting a review, the function subsequently deletes the comments subdocument array in it.
- * @returns {Promise<void>}
- */
-async function deleteCascadeComments() {
-	const commentIds = this.comments.map((comment) => comment._id)
-	await Comment.deleteMany({
-		_id: {
-			$in: commentIds,
-		},
-	})
-}
-
-reviewSchema.pre('deleteOne', { document: true }, deleteCascadeComments)
 
 export default mongoose.model('Review', reviewSchema)

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -10,7 +10,7 @@ router.post('/', async (req, res, next) => {
 
 	try {
 		// todo: Is there a way not to create the comments collection when creating a comment document?
-		const comment = await Comment.create(req.body)
+		const comment = new Comment(req.body)
 
 		await Review.findByIdAndUpdate(reviewId, {
 			$push: {


### PR DESCRIPTION
As comments collection is not created, review schema's middleware is no longer needed.