### PR TITLE
Update likes

### DIFF
--- a/models/collection.js
+++ b/models/collection.js
@@ -33,7 +33,11 @@ const collectionSchema = new mongoose.Schema({
 		type: [mongoose.Schema.Types.ObjectId],
 		ref: 'User',
 	},
-	created_at : {
+	likeCount: {
+		type: Number,
+		default: 0,
+	},
+	created_at: {
 		type: Date,
 		default: Date.now,
 		immutable: true
@@ -41,7 +45,11 @@ const collectionSchema = new mongoose.Schema({
 	commented_users:{
 		type: [mongoose.Schema.Types.ObjectId],
 		ref: 'User',
-	}
+	},
+})
+
+collectionSchema.pre('save', function () {
+	this.likeCount = this.liked_users.length
 })
 
 export default mongoose.model('Collection', collectionSchema)

--- a/models/review.js
+++ b/models/review.js
@@ -28,10 +28,14 @@ const reviewSchema = new mongoose.Schema({
 		type: [mongoose.Schema.Types.ObjectId],
 		ref: 'User',
 	},
-    commented_users:{
-        type: [mongoose.Schema.Types.ObjectId],
+	likeCount: {
+		type: Number,
+		default: 0,
+	},
+	commented_users: {
+		type: [mongoose.Schema.Types.ObjectId],
 		ref: 'User',
-    }
+	},
 })
 
 class Review {

--- a/models/review.js
+++ b/models/review.js
@@ -50,10 +50,6 @@ class Review {
 	getMyLike(userId) {
 		return this.liked_users.includes(userId)
 	}
-
-	get likes() {
-		return this.liked_users.length
-	}
 }
 
 reviewSchema.loadClass(Review)

--- a/models/review.js
+++ b/models/review.js
@@ -50,6 +50,10 @@ class Review {
 		delete review.liked_users
 		return review
 	}
+
+	getMyLike(userId) {
+		return this.liked_users.includes(userId)
+	}
 }
 
 reviewSchema.pre('save', function () {

--- a/models/review.js
+++ b/models/review.js
@@ -50,10 +50,6 @@ class Review {
 		delete review.liked_users
 		return review
 	}
-
-	getMyLike(userId) {
-		return this.liked_users.includes(userId)
-	}
 }
 
 reviewSchema.pre('save', function () {

--- a/models/review.js
+++ b/models/review.js
@@ -56,6 +56,10 @@ class Review {
 	}
 }
 
+reviewSchema.pre('save', function () {
+	this.likeCount = this.liked_users.length
+})
+
 reviewSchema.loadClass(Review)
 
 export default mongoose.model('Review', reviewSchema)

--- a/models/utilities.js
+++ b/models/utilities.js
@@ -1,0 +1,31 @@
+import { User } from './index.js'
+
+/**
+ * Apply (un)like.
+ * @param Model {mongoose.Model}
+ * @param documentId {any}
+ * @param userId {any}
+ * @returns {Promise<Document<*|*|Error>>}
+ */
+const likeUnlike = async (Model, documentId, userId) => {
+	try {
+		let document =
+			(await Model.findById(documentId)) ??
+			new Error('존재하지 않는 리뷰입니다.')
+
+		await User.getExpAndLevelUp(document.user, 'like')
+
+		document.getMyLike(userId)
+			? document.liked_users.pull(userId)
+			: document.liked_users.push(userId)
+
+		await document.save()
+
+		document = Model.processLikesInfo(document, userId)
+		return document
+	} catch (e) {
+		return e
+	}
+}
+
+export { likeUnlike }

--- a/routes/collections.js
+++ b/routes/collections.js
@@ -5,6 +5,7 @@ import nonAuthMiddleware from '../middleware/non_auth_middleware.js'
 import multer from 'multer'
 import ImageUpload from '../controllers/image_upload.js'
 import { validateId } from '../controllers/utilities.js'
+import { likeUnlike } from '../models/utilities'
 
 const router = new express.Router()
 const upload = multer({
@@ -165,4 +166,7 @@ router.delete('/:collectionId/comments/:commentId', async (req, res, next) => {
 		return next(new Error('댓글 삭제를 실패했습니다.'))
 	}
 })
+
+router.put('/:collectionId/likes', authMiddleware, await likeUnlike(Collection, 'collection'))
+
 export default router

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import { Book, Review, User } from '../models/index.js'
+import { likeUnlike } from '../models/utilities.js'
 import saveBook from '../controllers/save_book.js'
 import searchBooks from '../controllers/searchbooks.js'
 import authMiddleware from '../middleware/auth_middleware.js'
@@ -149,27 +150,6 @@ router.delete('/:reviewId', authMiddleware, async (req, res) => {
 		return next(new Error('리뷰 삭제를 실패했습니다.'))
 	}
 })
-
-const likeUnlike = async (Model, documentId, userId) => {
-	try {
-		let document =
-			(await Model.findById(documentId)) ??
-			new Error('존재하지 않는 리뷰입니다.')
-
-		await User.getExpAndLevelUp(document.user, 'like')
-
-		document.getMyLike(userId)
-			? document.liked_users.pull(userId)
-			: document.liked_users.push(userId)
-
-		await document.save()
-
-		document = Model.processLikesInfo(document, userId)
-		return document
-	} catch (e) {
-		return e
-	}
-}
 
 router.put('/:reviewId/likes', authMiddleware, async (req, res, next) => {
 	const { _id: userId } = res.locals.user

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -151,17 +151,6 @@ router.delete('/:reviewId', authMiddleware, async (req, res) => {
 	}
 })
 
-router.put('/:reviewId/likes', authMiddleware, async (req, res, next) => {
-	const { _id: userId } = res.locals.user
-	const { reviewId } = req.params
-    
-    try{
-        const review = await likeUnlike(Review, reviewId, userId)
-		return res.json({ review })
-	} catch (e) {
-		console.error(e)
-		return next(new Error('좋아요/좋아요취소 를 실패했습니다.'))
-	}
-})
+router.put('/:reviewId/likes', authMiddleware, await likeUnlike(Review, 'review'))
 
 export default router


### PR DESCRIPTION
1. 좋아요 수 집계 방식 변화

기존: 버추얼을 이용해 구현

개선: pre 미들웨어를 이용해 db에 실제 저장

이유: 추후 좋아요 수를 이용한 정렬이 좀더 수월해짐

2. 좋아요 라우터 자체의 추상화

기존: 리뷰와 컬렉션에 중복 코드 존재

개선: 추상화해서 utilities로 뺌

이유: 코드 중복 감소